### PR TITLE
Limit documentation TOC depth

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,6 +46,10 @@ autodoc_mock_imports = ["win32com"]
 #
 html_theme = 'sphinx_rtd_theme'
 
+html_theme_options = {
+    'navigation_depth': 1
+}
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,7 +8,7 @@ Currently it is just a thin wrapper around the COM API, but future plans will be
 the interface to be more Pythonic.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: COM API
 
    application


### PR DESCRIPTION
The behaviour seems to have changed with a newer version of Sphinx. These changes are needed to limit the expansion of the sidebar and the extra bullet points on the TOC page.