### PR TITLE
Fix tests broken by changes to sample files

### DIFF
--- a/test/test_page.py
+++ b/test/test_page.py
@@ -32,7 +32,11 @@ class TestPage(unittest.TestCase, SamplePath, ExtraAsserts):
         self.assertEqual(self.page.document_height, 491)
 
     def test_document_width(self):
-        self.assertAttrEqual(self.page, "document_width", 2826)
+        # Make sure the initial document width isn't what we're about to change
+        # it to.
+        self.assertNotEqual(self.page.document_width, 200)
+
+        # Test a width change.
         self.assertAttrChange(self.page, "document_width", 200)
 
     def test_paper_mode(self):

--- a/test/test_title.py
+++ b/test/test_title.py
@@ -17,8 +17,11 @@ class TestTitle(unittest.TestCase, SamplePath, ExtraAsserts):
         cls.app.quit(False)
 
     def test_position(self):
-        self.assertAttrEqual(self.title, "left_position", 0.08062253892421722)
-        self.assertAttrEqual(self.title, "right_position", 0.14869199693202972)
+        # Ensure our left/right positions aren't already what we're about to set them to.
+        self.assertNotEqual(self.title.left_position, 0.1)
+        self.assertNotEqual(self.title.right_position, 0.4)
+
+        # Test the change.
         self.assertAttrAlmostChange(self.title, "left_position", 0.1, 3)
         self.assertAttrAlmostChange(self.title, "right_position", 0.4, 3)
 


### PR DESCRIPTION
We're unfortunately using sample files as test fixtures, and some of them were redone with recent releases. There were a couple of assertions in our tests that were relying on specific positions or sizes of some items.

This PR updates them to remove those restrictions, and instead just attempts to change/update them instead. It isn't the best fix, but ultimately I can't just update the values as it'll cause tests to fail for older versions of WellCAD.