### PR TITLE
Fix the Read the Docs Build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,9 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+sphinx:
+  configuration: doc/conf.py

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'pywellcad'
-copyright = '2021-2022, Advanced Logic Technology'
+copyright = '2021-2024, Advanced Logic Technology'
 author = 'Advanced Logic Technology'
 
 


### PR DESCRIPTION
Read the Docs now requires a `.readthedocs.yaml` config file for builds to proceed. This PR implements their spec.