### PR TITLE
Remove horizontal stress calculation method

### DIFF
--- a/test/fixtures/Process.ini
+++ b/test/fixtures/Process.ini
@@ -123,24 +123,6 @@ AttributeValues2 = cont, part
 DepthRange = Maximum
 
 
-[HorzStress]
-; input : log (image log), borehole pressure, pore pressure, compressive strength, min horizontal stress, young's modulus, poisson's ratio, borehole radius
-; units : MPa, Pa, GPa (pressure), us, s, ms (radius traveltime)
-; output : log (major stress + minor stress + deformation azimut  or major stress + deformation azimut)
-ClipLow = 0
-ClipHigh = 100
-EnableClipping = yes
-Sensitivity = 7
-Deformation = 1
-BHPressure = 20
-BHPressureUnit = MPa
-PorePressure = 18
-PorePressureUnit = MPa
-CompStrength = 30
-CompStrengthUnit = MPa
-ShMin = 23
-ShMinUnit = MPa
-
 [BreakoutAutoPick]
 ; input : log (image log), sensitivity
 ; output : breakout log + breakout length log

--- a/test/test_borehole_image_and_structure.py
+++ b/test/test_borehole_image_and_structure.py
@@ -148,12 +148,6 @@ class TestBoreholeImageAndStructure(unittest.TestCase, ExtraAsserts, SamplePath)
         self.orient_borehole.remove_log("Breakout Log")
         self.orient_borehole.remove_log("Breakout Diameter")
 
-    def test_horz_stress(self):
-        self.orient_borehole.horz_stress(log="Amplitude", prompt_user=False, config=self.config_file)
-        self.assertIsInstance(self.orient_borehole.get_log("Major stress (breakout)"), wellcad.com.Log)
-        self.assertIsInstance(self.orient_borehole.get_log("Minor stress orientation"), wellcad.com.Log)
-        self.orient_borehole.remove_log("Major stress (breakout)")
-        self.orient_borehole.remove_log("Minor stress orientation")
 
 if __name__ == '__main__':
     unittest.main()

--- a/wellcad/com/_borehole.py
+++ b/wellcad/com/_borehole.py
@@ -21,7 +21,7 @@ class Borehole(DispatchWrapper):
                          "CalculateApparentMetalLoss", "GetLog", "CreateNewWorkspace",  "Workspace", "FileExport",
                          "ConvertLogTo", "FilterLog", "ResampleLog", "InterpolateLog", "ElogCorrection",
                          "NMRFluidVolumes", "ROPAverage", "SharpenRGBLog", "RetinexFilterRGBLog", 
-                         "Transmissivity", "ShearWaveVelocity", "EllipseFitting", "BreakoutAutoPick", "HorzStress",
+                         "Transmissivity", "ShearWaveVelocity", "EllipseFitting", "BreakoutAutoPick",
                          "CreateLinkedLog")
 
     @property
@@ -4214,55 +4214,6 @@ class Borehole(DispatchWrapper):
         """
 
         self._dispatch.DeleteMetadata(id)
-
-    
-    def horz_stress(self, log=None, prompt_user=None, config=None):
-        """Computes the hydraulic conductivity from permeability data.
-
-        Parameters
-        ----------
-        log : image log
-            Title of the log containing the televiewer data.
-            If not provided, the process doesn't run.
-        prompt_user : bool, optional
-            Whether dialog boxes are displayed to interact with the user.
-            If set to ``False`` the processing parameters will be retrieved from the specified
-            configuration.  If no configuration has been specified, default values will be used.
-            Default is True.
-        config : bool, optional
-            Path to a configuration file or a parameter string. The
-            configuration file can contain the following options:
-
-            .. code-block:: ini
-
-                [HorzStress]
-                ; input : log (image log), borehole pressure, pore pressure, compressive strength, min horizontal stress, young's modulus, poisson's ratio, borehole radius
-                ; units : MPa, Pa, GPa (pressure), us, s, ms (radius traveltime)
-                ; output : log (major stress + minor stress + deformation azimut  or major stress + deformation azimut)
-
-                ClipLow = 0
-                ClipHigh = 100
-                EnableClipping = yes
-                Sensitivity = 7
-
-                Deformation = 1
-                BHPressure = 20
-                BHPressureUnit = MPa
-                PorePressure = 18
-                PorePressureUnit = MPa
-                CompStrength = 30
-                CompStrengthUnit = MPa
-                ShMin = 23
-                ShMinUnit = MPa
-
-        Returns
-        -------
-        Log
-            Three logs containing the minor stress, the major stress and the minor stress direction (elastic deformation)
-            Two logs containing the major horizontal stress and the minor stress direction (breakout)
-        """
-
-        return Log(self._dispatch.HorzStress(log, prompt_user, config))
 
 
     def ellipse_fitting(self, log=None, prompt_user=None, config=None):


### PR DESCRIPTION
This should fix #149. It reverts part of #140, as it was decided that the horizontal stress calculation method wasn't quite ready for public consumption.